### PR TITLE
Update library versions and fix compatibility issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 .DS_Store
 
 # Firebase sensitive files
-google-services.json
+app/google-services.json
 app/google-services.json
 /build
 /app/build

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,12 +2,12 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
     alias(libs.plugins.detekt)
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.crashlytics)
-    kotlin("plugin.serialization") version "2.0.21"
 }
 
 android {
@@ -22,11 +22,6 @@ android {
         versionName = "1.2"
 
         testInstrumentationRunner = "es.itram.basketmatch.HiltTestRunner"
-        
-        // Room schema export configuration
-        ksp {
-            arg("room.schemaLocation", "$projectDir/schemas")
-        }
     }
 
     buildTypes {
@@ -48,18 +43,18 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true
         buildConfig = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.composeBom.get()
+        kotlinCompilerExtensionVersion = "1.5.15"
     }
     packaging {
         resources {
@@ -81,6 +76,11 @@ android {
     }
 }
 
+// Room schema export configuration
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+}
+
 dependencies {
     // Core Android
     implementation(libs.androidx.core.ktx)
@@ -93,6 +93,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material3.icons)
     
     // Architecture Components
     implementation(libs.androidx.lifecycle.viewmodel.compose)
@@ -121,8 +122,8 @@ dependencies {
     implementation(libs.jsoup)
     
     // Kotlin Serialization
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-    
+    implementation(libs.kotlinx.serialization.json)
+
     // Image Loading
     implementation(libs.coil.compose)
     

--- a/app/src/main/java/es/itram/basketmatch/di/FirebaseModule.kt
+++ b/app/src/main/java/es/itram/basketmatch/di/FirebaseModule.kt
@@ -1,10 +1,10 @@
 package es.itram.basketmatch.di
 
+import com.google.firebase.Firebase
 import com.google.firebase.analytics.FirebaseAnalytics
-import com.google.firebase.analytics.ktx.analytics
+import com.google.firebase.analytics.analytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
-import com.google.firebase.crashlytics.ktx.crashlytics
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.crashlytics.crashlytics
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -36,7 +36,7 @@ object FirebaseModule {
     fun provideFirebaseCrashlytics(): FirebaseCrashlytics {
         return Firebase.crashlytics.apply {
             // Configurar Crashlytics
-            setCrashlyticsCollectionEnabled(true)
+            isCrashlyticsCollectionEnabled = true
         }
     }
 }

--- a/app/src/main/java/es/itram/basketmatch/presentation/component/EnhancedMatchCard.kt
+++ b/app/src/main/java/es/itram/basketmatch/presentation/component/EnhancedMatchCard.kt
@@ -11,10 +11,9 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
-import androidx.compose.material.icons.filled.Place
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -26,14 +25,12 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import es.itram.basketmatch.R
 import es.itram.basketmatch.domain.entity.Match
 import es.itram.basketmatch.domain.entity.MatchStatus
 import java.time.format.DateTimeFormatter

--- a/app/src/main/java/es/itram/basketmatch/presentation/viewmodel/ContactViewModel.kt
+++ b/app/src/main/java/es/itram/basketmatch/presentation/viewmodel/ContactViewModel.kt
@@ -45,7 +45,8 @@ class ContactViewModel @Inject constructor(
                 // En caso de error, mantener la info por defecto
                 analyticsManager.trackError(
                     errorType = "contact_info_load_error",
-                    errorMessage = e.message ?: "Unknown error loading contact info"
+                    errorMessage = e.message ?: "Unknown error loading contact info",
+                    eventName = "loadContactInfo"
                 )
             } finally {
                 _isLoading.value = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,50 +1,53 @@
 [versions]
-agp = "8.12.0"
-kotlin = "2.0.21"
-coreKtx = "1.16.0"
+agp = "8.13.0"
+kotlin = "2.2.20"
+coreKtx = "1.17.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.9.2"
-activityCompose = "1.10.1"
-composeBom = "2024.09.00"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
+lifecycleRuntimeKtx = "2.9.4"
+activityCompose = "1.11.0"
+composeBom = "2025.09.01"
 
 # Architecture & DI
-hilt = "2.48"
-navigation = "2.8.4"
-lifecycle = "2.9.2"
+hilt = "2.57.2"
+navigation = "2.9.5"
+lifecycle = "2.9.4"
 
 # Network
 retrofit = "2.11.0"
 okhttp = "4.12.0"
-gson = "2.11.0"
-jsoup = "1.18.1"
+gson = "2.13.2"
+jsoup = "1.21.2"
 
 # Database
-room = "2.6.1"
+room = "2.8.1"
 
 # Image Loading
 coil = "2.7.0"
 
 # Testing
-mockk = "1.13.13"
+mockk = "1.14.6"
 
 # Code Quality
-detekt = "1.23.7"
-coroutines-test = "1.9.0"
+detekt = "1.23.8"
+coroutines-test = "1.10.2"
 arch-testing = "2.2.0"
-turbine = "1.1.0"
-truth = "1.4.4"
+turbine = "1.2.1"
+truth = "1.4.5"
 
-# KSP for annotation processing
-ksp = "2.0.21-1.0.25"
+# KSP for annotation processing - actualizado para compatibilidad con Kotlin 2.2.20
+ksp = "2.2.20-2.0.3"
+
+# Kotlin Serialization - actualizado para compatibilidad
+kotlinx-serialization = "1.9.0"
 
 # Firebase
-firebase-bom = "33.1.2"
-google-services = "4.4.2"
+firebase-bom = "34.3.0"
+google-services = "4.4.3"
 
 # WorkManager for scheduling
-workmanager = "2.9.1"
+workmanager = "2.10.5"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -61,6 +64,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material3-icons = { group = "androidx.compose.material", name = "material-icons-core" }
 
 # Architecture & ViewModel
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
@@ -73,7 +77,7 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 # Hilt - Dependency Injection
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
-androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.2.0" }
+androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.3.0" }
 
 # Room - Database
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
@@ -90,6 +94,9 @@ jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 
 # Image Loading
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+
+# Kotlin Serialization
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 # Testing
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
@@ -108,15 +115,15 @@ firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging
 
 # WorkManager
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workmanager" }
-androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version = "1.2.0" }
+androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version = "1.3.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.2" }
-
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.6" }


### PR DESCRIPTION
- Updated Kotlin to 2.2.20 with compatible KSP 2.2.20-2.0.3
- Updated Java target from 11 to 17
- Updated Hilt from 2.48 to 2.57.2
- Updated Compose BOM to 2025.09.01
- Updated Room from 2.6.1 to 2.8.1
- Updated Navigation Compose to 2.9.5
- Updated Firebase BOM to 34.3.0
- Updated Kotlin Serialization to 1.9.0
- Fixed 'unexpected jvm signature V' error
- Fixed KSP configuration compatibility
- Migrated plugin declarations to version catalog